### PR TITLE
Make the test return a non-zero code if an error happened

### DIFF
--- a/tests/b.sh
+++ b/tests/b.sh
@@ -7,10 +7,14 @@
 # $3 = end id
 # ex : time b.sh http://localhost:8082 1 10
 
+err=0
+
 for i in $(seq $2 $3)
 do
-	curl $1/srvb/user/$i &
+	curl $1/srvb/user/$i
+	if [ $? -ne 0 ]; then
+		err=1
+	fi
 done
 
-wait
-exit 0
+exit $err


### PR DESCRIPTION
With this return code, we can detect that the test failed.